### PR TITLE
implement JSONMarshal/JSONUnmarshal to provide the ability to store DAG

### DIFF
--- a/dag_test.go
+++ b/dag_test.go
@@ -121,6 +121,53 @@ func TestDAG_AddVertex2(t *testing.T) {
 	}
 }
 
+func TestDAG_AddVertexByID(t *testing.T) {
+	dag := NewDAG()
+
+	// add a single vertex and inspect the graph
+	v := iVertex{1}
+	id := "1"
+	_ = dag.AddVertexByID(id, v)
+	if id != v.ID() {
+		t.Errorf("GetOrder().ID() = %s, want %s", id, v.ID())
+	}
+	vertices := dag.GetVertices()
+	if vertices := len(vertices); vertices != 1 {
+		t.Errorf("GetVertices() = %d, want 1", vertices)
+	}
+
+	if _, exists := vertices[id]; !exists {
+		t.Errorf("GetVertices()[id] = false, want true")
+	}
+
+	// duplicate
+	errDuplicate := dag.AddVertexByID(id, v)
+	if errDuplicate == nil {
+		t.Errorf("AddVertexByID(id, v) = nil, want %T", VertexDuplicateError{v})
+	}
+	if _, ok := errDuplicate.(VertexDuplicateError); !ok {
+		t.Errorf("AddVertexByID(id, v) expected VertexDuplicateError, got %T", errDuplicate)
+	}
+
+	// duplicate
+	_, errIDDuplicate := dag.AddVertex(foobarKey{MyID: "1"})
+	if errIDDuplicate == nil {
+		t.Errorf("AddVertex(foobarKey{MyID: \"1\"}) = nil, want %T", IDDuplicateError{"1"})
+	}
+	if _, ok := errIDDuplicate.(IDDuplicateError); !ok {
+		t.Errorf("AddVertex(foobarKey{MyID: \"1\"}) expected IDDuplicateError, got %T", errIDDuplicate)
+	}
+
+	// nil
+	errNil := dag.AddVertexByID("2", nil)
+	if errNil == nil {
+		t.Errorf(`AddVertexByID("2", nil) = nil, want %T`, VertexNilError{})
+	}
+	if _, ok := errNil.(VertexNilError); !ok {
+		t.Errorf(`AddVertexByID("2", nil) expected VertexNilError, got %T`, errNil)
+	}
+}
+
 func TestDAG_GetVertex(t *testing.T) {
 	dag := NewDAG()
 	v1 := iVertex{1}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.12
 // require github.com/hashicorp/terraform v0.12.20
 
 require (
+	github.com/emirpasic/gods v1.18.1
 	github.com/go-test/deep v1.0.7
 	github.com/google/uuid v1.1.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
+github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/go-test/deep v1.0.7 h1:/VSMRlnY/JSyqxQUzQLKVMAskpY/NZKFA5j2P+0pP2M=
 github.com/go-test/deep v1.0.7/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=

--- a/marshal.go
+++ b/marshal.go
@@ -1,0 +1,79 @@
+package dag
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// MarshalJSON returns the JSON encoding of DAG.
+//
+// It traverses the DAG using the Depth-First-Search algorithm
+// and uses an internal structure to store vertices and edges.
+func (d *DAG) MarshalJSON() ([]byte, error) {
+	mv := newMarshalVisitor(d)
+	DFSWalk(d, mv)
+	return json.Marshal(mv.storableDAG)
+}
+
+// UnmarshalJSON is an informative method. See the UnmarshalJSON function below.
+func (d *DAG) UnmarshalJSON(data []byte) error {
+	return errors.New("This method is not supported, request function UnmarshalJSON instead")
+}
+
+// UnmarshalJSON parses the JSON-encoded data that defined by StorableDAG.
+// It returns a new DAG defined by the vertices and edges of wd.
+// If the internal structure of data and wd do not match,
+// then deserialization will fail and return json eror
+//
+// Because the vertex data passed in by the user is an interface{},
+// it does not indicate a specific structure, so it cannot be deserialized.
+// And this function needs to pass in a clear DAG structure.
+//
+// Example:
+// dag := NewDAG()
+// data, err := json.Marshal(d)
+// if err != nil {
+//     panic(err)
+// }
+// var wd YourStorableDAG
+// restoredDag, err := UnmarshalJSON(data, &wd)
+// if err != nil {
+//     panic(err)
+// }
+//
+// For more specific information please read the test code.
+func UnmarshalJSON(data []byte, wd StorableDAG) (*DAG, error) {
+	err := json.Unmarshal(data, &wd)
+	if err != nil {
+		return nil, err
+	}
+	dag := NewDAG()
+	for _, v := range wd.Vertices() {
+		dag.AddVertexByID(v.Vertex())
+	}
+	for _, e := range wd.Edges() {
+		dag.AddEdge(e.Edge())
+	}
+	return dag, nil
+}
+
+type marshalVisitor struct {
+	d *DAG
+	storableDAG
+}
+
+func newMarshalVisitor(d *DAG) *marshalVisitor {
+	return &marshalVisitor{d: d}
+}
+
+func (mv *marshalVisitor) Visit(v Vertexer) {
+	mv.StorableVertices = append(mv.StorableVertices, v)
+
+	srcID, _ := v.Vertex()
+	children, _ := mv.d.getChildren(srcID)
+	ids := vertexIDs(children)
+	for _, dstID := range ids {
+		e := storableEdge{SrcID: srcID, DstID: dstID}
+		mv.StorableEdges = append(mv.StorableEdges, e)
+	}
+}

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1,0 +1,52 @@
+package dag
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/go-test/deep"
+)
+
+func getTestMarshalDAG() *DAG {
+	dag := NewDAG()
+	v1, v2, v3, v4, v5 := "1", "2", "3", "4", "5"
+	_ = dag.AddVertexByID(v1, "v1")
+	_ = dag.AddVertexByID(v2, "v2")
+	_ = dag.AddVertexByID(v3, "v3")
+	_ = dag.AddVertexByID(v4, "v4")
+	_ = dag.AddVertexByID(v5, "v5")
+	_ = dag.AddEdge(v1, v2)
+	_ = dag.AddEdge(v2, v3)
+	_ = dag.AddEdge(v2, v4)
+	_ = dag.AddEdge(v4, v5)
+	return dag
+}
+
+func TestMarshalUnmarshalJSON(t *testing.T) {
+	d := getTestMarshalDAG()
+	data, err := json.Marshal(d)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expected := `{"vs":[{"i":"1","v":"v1"},{"i":"2","v":"v2"},{"i":"3","v":"v3"},{"i":"4","v":"v4"},{"i":"5","v":"v5"}],"es":[{"s":"1","d":"2"},{"s":"2","d":"3"},{"s":"2","d":"4"},{"s":"4","d":"5"}]}`
+	actual := string(data)
+	if deep.Equal(expected, actual) != nil {
+		t.Errorf("Marshal() = %v, want %v", actual, expected)
+	}
+
+	d1 := &DAG{}
+	errNotSupported := json.Unmarshal(data, d1)
+	if errNotSupported == nil {
+		t.Errorf("UnmarshalJSON() = nil, want %v", "This method is not supported")
+	}
+
+	var wd testStorableDAG
+	dag, err := UnmarshalJSON(data, &wd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deep.Equal(d, dag) != nil {
+		t.Errorf("UnmarshalJSON() = %v, want %v", dag.String(), d.String())
+	}
+}

--- a/storage.go
+++ b/storage.go
@@ -1,0 +1,75 @@
+package dag
+
+var (
+	_ Vertexer    = (*storableVertex)(nil)
+	_ Edger       = (*storableEdge)(nil)
+	_ StorableDAG = (*storableDAG)(nil)
+	_ IDInterface = (*storableVertex)(nil)
+)
+
+// Vertexer is the interface that wraps the basic Vertex method.
+// Vertex returns an id that identifies this vertex and the value of this vertex.
+//
+// The reason for defining this new structure is
+// because the vertex id may be automatically generated when the caller adds a vertex.
+// At this time, the vertex structure added by the user does not contain id information.
+type Vertexer interface {
+	Vertex() (id string, value interface{})
+}
+
+// Edger is the interface that wraps the basic Edge method.
+// Edge returns the ids of two vertices that connect an edge.
+type Edger interface {
+	Edge() (srcID, dstID string)
+}
+
+// StorableDAG is the interface that defines a DAG that can be stored.
+// It provides methods to get all vertices and all edges of a DAG.
+type StorableDAG interface {
+	Vertices() []Vertexer
+	Edges() []Edger
+}
+
+// storableVertex implements the Vertexer interface.
+// It is implemented as a storable structure.
+// And it uses short json tag to reduce the number of bytes after serialization.
+type storableVertex struct {
+	WrappedID string      `json:"i"`
+	Value     interface{} `json:"v"`
+}
+
+func (v storableVertex) Vertex() (id string, value interface{}) {
+	return v.WrappedID, v.Value
+}
+
+func (v storableVertex) ID() string {
+	return v.WrappedID
+}
+
+// storableEdge implements the Edger interface.
+// It is implemented as a storable structure.
+// And it uses short json tag to reduce the number of bytes after serialization.
+type storableEdge struct {
+	SrcID string `json:"s"`
+	DstID string `json:"d"`
+}
+
+func (e storableEdge) Edge() (srcID, dstID string) {
+	return e.SrcID, e.DstID
+}
+
+// storableDAG implements the StorableDAG interface.
+// It acts as a serializable operable structure.
+// And it uses short json tag to reduce the number of bytes after serialization.
+type storableDAG struct {
+	StorableVertices []Vertexer `json:"vs"`
+	StorableEdges    []Edger    `json:"es"`
+}
+
+func (g storableDAG) Vertices() []Vertexer {
+	return g.StorableVertices
+}
+
+func (g storableDAG) Edges() []Edger {
+	return g.StorableEdges
+}

--- a/storage_test.go
+++ b/storage_test.go
@@ -1,0 +1,44 @@
+package dag
+
+type testVertex struct {
+	WID string `json:"i"`
+	Val string `json:"v"`
+}
+
+func (tv testVertex) ID() string {
+	return tv.WID
+}
+
+func (tv testVertex) Vertex() (id string, value interface{}) {
+	return tv.WID, tv.Val
+}
+
+type testEdge struct {
+	SrcID string `json:"s"`
+	DstID string `json:"d"`
+}
+
+func (e testEdge) Edge() (srcID, dstID string) {
+	return e.SrcID, e.DstID
+}
+
+type testStorableDAG struct {
+	StorableVertices []testVertex   `json:"vs"`
+	StorableEdges    []storableEdge `json:"es"`
+}
+
+func (g testStorableDAG) Vertices() []Vertexer {
+	l := make([]Vertexer, 0, len(g.StorableVertices))
+	for _, v := range g.StorableVertices {
+		l = append(l, v)
+	}
+	return l
+}
+
+func (g testStorableDAG) Edges() []Edger {
+	l := make([]Edger, 0, len(g.StorableEdges))
+	for _, v := range g.StorableEdges {
+		l = append(l, v)
+	}
+	return l
+}

--- a/visitor.go
+++ b/visitor.go
@@ -1,0 +1,97 @@
+package dag
+
+import (
+	"sort"
+
+	llq "github.com/emirpasic/gods/queues/linkedlistqueue"
+	lls "github.com/emirpasic/gods/stacks/linkedliststack"
+)
+
+// Visitor is the interface that wraps the basic Visit method.
+// It can use the Visitor and XXXWalk functions together to traverse the entire DAG.
+// And access per-vertex information when traversing.
+type Visitor interface {
+	Visit(Vertexer)
+}
+
+// DFSWalk implements the Depth-First-Search algorithm to traverse the entire DAG.
+// The algorithm starts at the root node and explores as far as possible
+// along each branch before backtracking.
+func DFSWalk(d *DAG, visitor Visitor) {
+	d.muDAG.RLock()
+	defer d.muDAG.RUnlock()
+
+	stack := lls.New()
+
+	vertices := d.getRoots()
+	for _, id := range reversedVertexIDs(vertices) {
+		v := vertices[id]
+		sv := storableVertex{WrappedID: id, Value: v}
+		stack.Push(sv)
+	}
+
+	for !stack.Empty() {
+		v, _ := stack.Pop()
+		sv := v.(storableVertex)
+
+		visitor.Visit(sv)
+
+		vertices, _ := d.getChildren(sv.WrappedID)
+		for _, id := range reversedVertexIDs(vertices) {
+			v := vertices[id]
+			sv := storableVertex{WrappedID: id, Value: v}
+			stack.Push(sv)
+		}
+	}
+}
+
+// BFSWalk implements the Breadth-First-Search algorithm to traverse the entire DAG.
+// It starts at the tree root and explores all nodes at the present depth prior
+// to moving on to the nodes at the next depth level.
+func BFSWalk(d *DAG, visitor Visitor) {
+	d.muDAG.RLock()
+	defer d.muDAG.RUnlock()
+
+	queue := llq.New()
+
+	vertices := d.getRoots()
+	for _, id := range vertexIDs(vertices) {
+		v := vertices[id]
+		sv := storableVertex{WrappedID: id, Value: v}
+		queue.Enqueue(sv)
+	}
+
+	for !queue.Empty() {
+		v, _ := queue.Dequeue()
+		sv := v.(storableVertex)
+
+		visitor.Visit(sv)
+
+		vertices, _ := d.getChildren(sv.WrappedID)
+		for _, id := range vertexIDs(vertices) {
+			v := vertices[id]
+			sv := storableVertex{WrappedID: id, Value: v}
+			queue.Enqueue(sv)
+		}
+	}
+}
+
+func vertexIDs(vertices map[string]interface{}) []string {
+	ids := make([]string, 0, len(vertices))
+	for id := range vertices {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func reversedVertexIDs(vertices map[string]interface{}) []string {
+	ids := vertexIDs(vertices)
+	i, j := 0, len(ids)-1
+	for i < j {
+		ids[i], ids[j] = ids[j], ids[i]
+		i++
+		j--
+	}
+	return ids
+}

--- a/visitor_test.go
+++ b/visitor_test.go
@@ -1,0 +1,56 @@
+package dag
+
+import (
+	"testing"
+
+	"github.com/go-test/deep"
+)
+
+type testVisitor struct {
+	Values []string
+}
+
+func (pv *testVisitor) Visit(v Vertexer) {
+	_, value := v.Vertex()
+	pv.Values = append(pv.Values, value.(string))
+}
+
+func getTestWalkDAG() *DAG {
+	dag := NewDAG()
+	v1, v2, v3, v4, v5 := "1", "2", "3", "4", "5"
+	_ = dag.AddVertexByID(v1, "v1")
+	_ = dag.AddVertexByID(v2, "v2")
+	_ = dag.AddVertexByID(v3, "v3")
+	_ = dag.AddVertexByID(v4, "v4")
+	_ = dag.AddVertexByID(v5, "v5")
+	_ = dag.AddEdge(v1, v2)
+	_ = dag.AddEdge(v2, v3)
+	_ = dag.AddEdge(v2, v4)
+	_ = dag.AddEdge(v4, v5)
+	return dag
+}
+
+func TestDFSWalk(t *testing.T) {
+	dag := getTestWalkDAG()
+
+	pv := &testVisitor{}
+	DFSWalk(dag, pv)
+
+	expected := []string{"v1", "v2", "v3", "v4", "v5"}
+	actual := pv.Values
+	if deep.Equal(expected, actual) != nil {
+		t.Errorf("DFSWalk() = %v, want %v", actual, expected)
+	}
+}
+
+func TestBFSWalk(t *testing.T) {
+	dag := getTestWalkDAG()
+	pv := &testVisitor{}
+	BFSWalk(dag, pv)
+
+	expected := []string{"v1", "v2", "v3", "v4", "v5"}
+	actual := pv.Values
+	if deep.Equal(expected, actual) != nil {
+		t.Errorf("BFSWalk() = %v, want %v", actual, expected)
+	}
+}


### PR DESCRIPTION
Sometimes we have some requirements and need to serialize the DAG. 
After serialization, we can store the DAG or transmit it on the network, which provides more usage scenarios for the dag library.

See `func (d *DAG) AddVertex(v interface{})`, which does not require that the vertex information passed in by the user must contain an id. Serializing the v parameter directly will lose the id information. Then I define a Vertexer interface, which contains the information of id and v.

The current unit tests have passed. Currently only JSON serialization is supported, and support for protobuf or msgpack can be added in the future to provide the ability to store or transmit binary data.
