### PR TITLE
Improve the readability of Walk and Marshal's unit tests

### DIFF
--- a/dag.go
+++ b/dag.go
@@ -325,6 +325,10 @@ func (d *DAG) DeleteEdge(srcID, dstID string) error {
 func (d *DAG) GetOrder() int {
 	d.muDAG.RLock()
 	defer d.muDAG.RUnlock()
+	return d.getOrder()
+}
+
+func (d *DAG) getOrder() int {
 	return len(d.vertices)
 }
 

--- a/marshal.go
+++ b/marshal.go
@@ -11,7 +11,7 @@ import (
 // and uses an internal structure to store vertices and edges.
 func (d *DAG) MarshalJSON() ([]byte, error) {
 	mv := newMarshalVisitor(d)
-	DFSWalk(d, mv)
+	d.DFSWalk(mv)
 	return json.Marshal(mv.storableDAG)
 }
 
@@ -76,6 +76,9 @@ func (mv *marshalVisitor) Visit(v Vertexer) {
 	mv.StorableVertices = append(mv.StorableVertices, v)
 
 	srcID, _ := v.Vertex()
+	// Why not use Mutex here?
+	// Because at the time of Walk,
+	// the read lock has been used to protect the dag.
 	children, _ := mv.d.getChildren(srcID)
 	ids := vertexIDs(children)
 	for _, dstID := range ids {

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -7,29 +7,40 @@ import (
 	"github.com/go-test/deep"
 )
 
-func getTestMarshalDAG() *DAG {
-	dag := NewDAG()
-	v1, v2, v3, v4, v5 := "1", "2", "3", "4", "5"
-	_ = dag.AddVertexByID(v1, "v1")
-	_ = dag.AddVertexByID(v2, "v2")
-	_ = dag.AddVertexByID(v3, "v3")
-	_ = dag.AddVertexByID(v4, "v4")
-	_ = dag.AddVertexByID(v5, "v5")
-	_ = dag.AddEdge(v1, v2)
-	_ = dag.AddEdge(v2, v3)
-	_ = dag.AddEdge(v2, v4)
-	_ = dag.AddEdge(v4, v5)
-	return dag
+func TestMarshalUnmarshalJSON(t *testing.T) {
+	cases := []struct {
+		dag      *DAG
+		expected string
+	}{
+		{
+			dag:      getTestWalkDAG(),
+			expected: `{"vs":[{"i":"1","v":"v1"},{"i":"2","v":"v2"},{"i":"3","v":"v3"},{"i":"4","v":"v4"},{"i":"5","v":"v5"}],"es":[{"s":"1","d":"2"},{"s":"2","d":"3"},{"s":"2","d":"4"},{"s":"4","d":"5"}]}`,
+		},
+		{
+			dag:      getTestWalkDAG2(),
+			expected: `{"vs":[{"i":"1","v":"v1"},{"i":"3","v":"v3"},{"i":"5","v":"v5"},{"i":"2","v":"v2"},{"i":"4","v":"v4"}],"es":[{"s":"1","d":"3"},{"s":"3","d":"5"},{"s":"2","d":"3"},{"s":"4","d":"5"}]}`,
+		},
+		{
+			dag:      getTestWalkDAG3(),
+			expected: `{"vs":[{"i":"1","v":"v1"},{"i":"3","v":"v3"},{"i":"2","v":"v2"},{"i":"4","v":"v4"},{"i":"5","v":"v5"}],"es":[{"s":"1","d":"3"},{"s":"2","d":"3"},{"s":"4","d":"5"}]}`,
+		},
+		{
+			dag:      getTestWalkDAG4(),
+			expected: `{"vs":[{"i":"1","v":"v1"},{"i":"2","v":"v2"},{"i":"3","v":"v3"},{"i":"5","v":"v5"},{"i":"4","v":"v4"}],"es":[{"s":"1","d":"2"},{"s":"2","d":"3"},{"s":"2","d":"4"},{"s":"3","d":"5"}]}`,
+		},
+	}
+
+	for _, c := range cases {
+		testMarshalUnmarshalJSON(t, c.dag, c.expected)
+	}
 }
 
-func TestMarshalUnmarshalJSON(t *testing.T) {
-	d := getTestMarshalDAG()
+func testMarshalUnmarshalJSON(t *testing.T, d *DAG, expected string) {
 	data, err := json.Marshal(d)
 	if err != nil {
 		t.Error(err)
 	}
 
-	expected := `{"vs":[{"i":"1","v":"v1"},{"i":"2","v":"v2"},{"i":"3","v":"v3"},{"i":"4","v":"v4"},{"i":"5","v":"v5"}],"es":[{"s":"1","d":"2"},{"s":"2","d":"3"},{"s":"2","d":"4"},{"s":"4","d":"5"}]}`
 	actual := string(data)
 	if deep.Equal(expected, actual) != nil {
 		t.Errorf("Marshal() = %v, want %v", actual, expected)

--- a/visitor.go
+++ b/visitor.go
@@ -17,7 +17,7 @@ type Visitor interface {
 // DFSWalk implements the Depth-First-Search algorithm to traverse the entire DAG.
 // The algorithm starts at the root node and explores as far as possible
 // along each branch before backtracking.
-func DFSWalk(d *DAG, visitor Visitor) {
+func (d *DAG) DFSWalk(visitor Visitor) {
 	d.muDAG.RLock()
 	defer d.muDAG.RUnlock()
 
@@ -30,11 +30,16 @@ func DFSWalk(d *DAG, visitor Visitor) {
 		stack.Push(sv)
 	}
 
+	visited := make(map[string]bool, d.getSize())
+
 	for !stack.Empty() {
 		v, _ := stack.Pop()
 		sv := v.(storableVertex)
 
-		visitor.Visit(sv)
+		if !visited[sv.WrappedID] {
+			visited[sv.WrappedID] = true
+			visitor.Visit(sv)
+		}
 
 		vertices, _ := d.getChildren(sv.WrappedID)
 		for _, id := range reversedVertexIDs(vertices) {
@@ -48,7 +53,7 @@ func DFSWalk(d *DAG, visitor Visitor) {
 // BFSWalk implements the Breadth-First-Search algorithm to traverse the entire DAG.
 // It starts at the tree root and explores all nodes at the present depth prior
 // to moving on to the nodes at the next depth level.
-func BFSWalk(d *DAG, visitor Visitor) {
+func (d *DAG) BFSWalk(visitor Visitor) {
 	d.muDAG.RLock()
 	defer d.muDAG.RUnlock()
 
@@ -61,11 +66,16 @@ func BFSWalk(d *DAG, visitor Visitor) {
 		queue.Enqueue(sv)
 	}
 
+	visited := make(map[string]bool, d.getOrder())
+
 	for !queue.Empty() {
 		v, _ := queue.Dequeue()
 		sv := v.(storableVertex)
 
-		visitor.Visit(sv)
+		if !visited[sv.WrappedID] {
+			visited[sv.WrappedID] = true
+			visitor.Visit(sv)
+		}
 
 		vertices, _ := d.getChildren(sv.WrappedID)
 		for _, id := range vertexIDs(vertices) {

--- a/visitor_test.go
+++ b/visitor_test.go
@@ -15,8 +15,20 @@ func (pv *testVisitor) Visit(v Vertexer) {
 	pv.Values = append(pv.Values, value.(string))
 }
 
+// schematic diagram:
+//     v5
+//     ^
+//     |
+//     v4
+//     ^
+//     |
+//     v2 --> v3
+//     ^
+//     |
+//     v1
 func getTestWalkDAG() *DAG {
 	dag := NewDAG()
+
 	v1, v2, v3, v4, v5 := "1", "2", "3", "4", "5"
 	_ = dag.AddVertexByID(v1, "v1")
 	_ = dag.AddVertexByID(v2, "v2")
@@ -27,30 +39,150 @@ func getTestWalkDAG() *DAG {
 	_ = dag.AddEdge(v2, v3)
 	_ = dag.AddEdge(v2, v4)
 	_ = dag.AddEdge(v4, v5)
+
+	return dag
+}
+
+// schematic diagram:
+//    v4 --> v5
+//           ^
+//           |
+//    v1 --> v3
+//           ^
+//           |
+//          v2
+func getTestWalkDAG2() *DAG {
+	dag := NewDAG()
+
+	v1, v2, v3, v4, v5 := "1", "2", "3", "4", "5"
+	_ = dag.AddVertexByID(v1, "v1")
+	_ = dag.AddVertexByID(v2, "v2")
+	_ = dag.AddVertexByID(v3, "v3")
+	_ = dag.AddVertexByID(v4, "v4")
+	_ = dag.AddVertexByID(v5, "v5")
+	_ = dag.AddEdge(v1, v3)
+	_ = dag.AddEdge(v2, v3)
+	_ = dag.AddEdge(v3, v5)
+	_ = dag.AddEdge(v4, v5)
+
+	return dag
+}
+
+// schematic diagram:
+//    v4 --> v5
+//
+//
+//    v1 --> v3
+//           ^
+//           |
+//          v2
+func getTestWalkDAG3() *DAG {
+	dag := NewDAG()
+
+	v1, v2, v3, v4, v5 := "1", "2", "3", "4", "5"
+	_ = dag.AddVertexByID(v1, "v1")
+	_ = dag.AddVertexByID(v2, "v2")
+	_ = dag.AddVertexByID(v3, "v3")
+	_ = dag.AddVertexByID(v4, "v4")
+	_ = dag.AddVertexByID(v5, "v5")
+	_ = dag.AddEdge(v1, v3)
+	_ = dag.AddEdge(v2, v3)
+	_ = dag.AddEdge(v4, v5)
+
+	return dag
+}
+
+// schematic diagram:
+//     v4     v5
+//     ^      ^
+//     |      |
+//     v2 --> v3
+//     ^
+//     |
+//     v1
+func getTestWalkDAG4() *DAG {
+	dag := NewDAG()
+
+	v1, v2, v3, v4, v5 := "1", "2", "3", "4", "5"
+	_ = dag.AddVertexByID(v1, "v1")
+	_ = dag.AddVertexByID(v2, "v2")
+	_ = dag.AddVertexByID(v3, "v3")
+	_ = dag.AddVertexByID(v4, "v4")
+	_ = dag.AddVertexByID(v5, "v5")
+	_ = dag.AddEdge(v1, v2)
+	_ = dag.AddEdge(v2, v3)
+	_ = dag.AddEdge(v3, v5)
+	_ = dag.AddEdge(v2, v4)
+
 	return dag
 }
 
 func TestDFSWalk(t *testing.T) {
-	dag := getTestWalkDAG()
+	cases := []struct {
+		dag      *DAG
+		expected []string
+	}{
+		{
+			dag:      getTestWalkDAG(),
+			expected: []string{"v1", "v2", "v3", "v4", "v5"},
+		},
+		{
+			dag:      getTestWalkDAG2(),
+			expected: []string{"v1", "v3", "v5", "v2", "v4"},
+		},
+		{
+			dag:      getTestWalkDAG3(),
+			expected: []string{"v1", "v3", "v2", "v4", "v5"},
+		},
+		{
+			dag:      getTestWalkDAG4(),
+			expected: []string{"v1", "v2", "v3", "v5", "v4"},
+		},
+	}
 
-	pv := &testVisitor{}
-	DFSWalk(dag, pv)
+	for _, c := range cases {
+		pv := &testVisitor{}
+		c.dag.DFSWalk(pv)
 
-	expected := []string{"v1", "v2", "v3", "v4", "v5"}
-	actual := pv.Values
-	if deep.Equal(expected, actual) != nil {
-		t.Errorf("DFSWalk() = %v, want %v", actual, expected)
+		expected := c.expected
+		actual := pv.Values
+		if deep.Equal(expected, actual) != nil {
+			t.Errorf("DFSWalk() = %v, want %v", actual, expected)
+		}
 	}
 }
 
 func TestBFSWalk(t *testing.T) {
-	dag := getTestWalkDAG()
-	pv := &testVisitor{}
-	BFSWalk(dag, pv)
+	cases := []struct {
+		dag      *DAG
+		expected []string
+	}{
+		{
+			dag:      getTestWalkDAG(),
+			expected: []string{"v1", "v2", "v3", "v4", "v5"},
+		},
+		{
+			dag:      getTestWalkDAG2(),
+			expected: []string{"v1", "v2", "v4", "v3", "v5"},
+		},
+		{
+			dag:      getTestWalkDAG3(),
+			expected: []string{"v1", "v2", "v4", "v3", "v5"},
+		},
+		{
+			dag:      getTestWalkDAG4(),
+			expected: []string{"v1", "v2", "v3", "v4", "v5"},
+		},
+	}
 
-	expected := []string{"v1", "v2", "v3", "v4", "v5"}
-	actual := pv.Values
-	if deep.Equal(expected, actual) != nil {
-		t.Errorf("BFSWalk() = %v, want %v", actual, expected)
+	for _, c := range cases {
+		pv := &testVisitor{}
+		c.dag.BFSWalk(pv)
+
+		expected := c.expected
+		actual := pv.Values
+		if deep.Equal(expected, actual) != nil {
+			t.Errorf("BFSWalk() = %v, want %v", actual, expected)
+		}
 	}
 }


### PR DESCRIPTION
@sebogh This modification adds new unit tests, and I also draw some simple diagrams to understand the DAG of the tests. The second modification is to remove the DFSWalk and BFSWalk functions and turn them into DAG methods.

Thanks for the nice library.