### PR TITLE
fix dag workflow bug, while dag has one node

### DIFF
--- a/dag.go
+++ b/dag.go
@@ -3,8 +3,9 @@ package dag
 
 import (
 	"fmt"
-	"github.com/google/uuid"
 	"sync"
+
+	"github.com/google/uuid"
 )
 
 // IDInterface describes the interface a type must implement in order to
@@ -913,6 +914,9 @@ func (d *DAG) DescendantsFlow(startID string, inputs []FlowResult, callback Flow
 	// really have an input channel regardless of how we traverse the tree and spawn
 	// workers.
 	leafCount := 0
+	if len(flowIDs) == 0 {
+		leafCount = 1
+	}
 	for id := range flowIDs {
 
 		// Get all parents of this vertex.


### PR DESCRIPTION
while dag has one node, run workflow (DescendantsFlow) will block