### PR TITLE
implement `OrderedWalk`: Walk in Topological Order

### DIFF
--- a/visitor_test.go
+++ b/visitor_test.go
@@ -16,16 +16,17 @@ func (pv *testVisitor) Visit(v Vertexer) {
 }
 
 // schematic diagram:
-//     v5
-//     ^
-//     |
-//     v4
-//     ^
-//     |
-//     v2 --> v3
-//     ^
-//     |
-//     v1
+//
+//	v5
+//	^
+//	|
+//	v4
+//	^
+//	|
+//	v2 --> v3
+//	^
+//	|
+//	v1
 func getTestWalkDAG() *DAG {
 	dag := NewDAG()
 
@@ -44,13 +45,14 @@ func getTestWalkDAG() *DAG {
 }
 
 // schematic diagram:
-//    v4 --> v5
-//           ^
-//           |
-//    v1 --> v3
-//           ^
-//           |
-//          v2
+//
+//	v4 --> v5
+//	       ^
+//	       |
+//	v1 --> v3
+//	       ^
+//	       |
+//	      v2
 func getTestWalkDAG2() *DAG {
 	dag := NewDAG()
 
@@ -69,13 +71,14 @@ func getTestWalkDAG2() *DAG {
 }
 
 // schematic diagram:
-//    v4 --> v5
+//
+//	v4 --> v5
 //
 //
-//    v1 --> v3
-//           ^
-//           |
-//          v2
+//	v1 --> v3
+//	       ^
+//	       |
+//	      v2
 func getTestWalkDAG3() *DAG {
 	dag := NewDAG()
 
@@ -93,13 +96,14 @@ func getTestWalkDAG3() *DAG {
 }
 
 // schematic diagram:
-//     v4     v5
-//     ^      ^
-//     |      |
-//     v2 --> v3
-//     ^
-//     |
-//     v1
+//
+//	v4     v5
+//	^      ^
+//	|      |
+//	v2 --> v3
+//	^
+//	|
+//	v1
 func getTestWalkDAG4() *DAG {
 	dag := NewDAG()
 
@@ -113,6 +117,32 @@ func getTestWalkDAG4() *DAG {
 	_ = dag.AddEdge(v2, v3)
 	_ = dag.AddEdge(v3, v5)
 	_ = dag.AddEdge(v2, v4)
+
+	return dag
+}
+
+// schematic diagram:
+//
+//	v5
+//	^
+//	|
+//	v3 <-- v4
+//	^      ^
+//	|      |
+//	v1     v2
+func getTestWalkDAG5() *DAG {
+	dag := NewDAG()
+
+	v1, v2, v3, v4, v5 := "1", "2", "3", "4", "5"
+	_ = dag.AddVertexByID(v1, "v1")
+	_ = dag.AddVertexByID(v2, "v2")
+	_ = dag.AddVertexByID(v3, "v3")
+	_ = dag.AddVertexByID(v4, "v4")
+	_ = dag.AddVertexByID(v5, "v5")
+	_ = dag.AddEdge(v1, v3)
+	_ = dag.AddEdge(v2, v4)
+	_ = dag.AddEdge(v4, v3)
+	_ = dag.AddEdge(v3, v5)
 
 	return dag
 }
@@ -137,6 +167,10 @@ func TestDFSWalk(t *testing.T) {
 		{
 			dag:      getTestWalkDAG4(),
 			expected: []string{"v1", "v2", "v3", "v5", "v4"},
+		},
+		{
+			dag:      getTestWalkDAG5(),
+			expected: []string{"v1", "v3", "v5", "v2", "v4"},
 		},
 	}
 
@@ -173,6 +207,10 @@ func TestBFSWalk(t *testing.T) {
 			dag:      getTestWalkDAG4(),
 			expected: []string{"v1", "v2", "v3", "v4", "v5"},
 		},
+		{
+			dag:      getTestWalkDAG5(),
+			expected: []string{"v1", "v2", "v3", "v4", "v5"},
+		},
 	}
 
 	for _, c := range cases {
@@ -183,6 +221,45 @@ func TestBFSWalk(t *testing.T) {
 		actual := pv.Values
 		if deep.Equal(expected, actual) != nil {
 			t.Errorf("BFSWalk() = %v, want %v", actual, expected)
+		}
+	}
+}
+
+func TestOrderedWalk(t *testing.T) {
+	cases := []struct {
+		dag      *DAG
+		expected []string
+	}{
+		{
+			dag:      getTestWalkDAG(),
+			expected: []string{"v1", "v2", "v3", "v4", "v5"},
+		},
+		{
+			dag:      getTestWalkDAG2(),
+			expected: []string{"v1", "v2", "v4", "v3", "v5"},
+		},
+		{
+			dag:      getTestWalkDAG3(),
+			expected: []string{"v1", "v2", "v4", "v3", "v5"},
+		},
+		{
+			dag:      getTestWalkDAG4(),
+			expected: []string{"v1", "v2", "v3", "v4", "v5"},
+		},
+		{
+			dag:      getTestWalkDAG5(),
+			expected: []string{"v1", "v2", "v4", "v3", "v5"},
+		},
+	}
+
+	for _, c := range cases {
+		pv := &testVisitor{}
+		c.dag.OrderedWalk(pv)
+
+		expected := c.expected
+		actual := pv.Values
+		if deep.Equal(expected, actual) != nil {
+			t.Errorf("OrderedWalk() = %v, want %v", actual, expected)
 		}
 	}
 }


### PR DESCRIPTION
For our project we need a way to walk the DAG in topological order, meaning that for any edge `a -> b` in the graph, node `a` is visited before node `b`. I implemented this algorithm, and added a test where topological sorting isn't given using the existing walkers.


The algorithm is almost the same as `BFSWalk`, except  that a vortex is pushed back to the queue if it has a parent that hasn't been visited yet. 