### PR TITLE
Add vertex hash function option

### DIFF
--- a/dag.go
+++ b/dag.go
@@ -28,6 +28,7 @@ type DAG struct {
 	verticesLocked   *dMutex
 	ancestorsCache   map[interface{}]map[interface{}]struct{}
 	descendantsCache map[interface{}]map[interface{}]struct{}
+	options          Options
 }
 
 // NewDAG creates / initializes a new DAG.
@@ -40,6 +41,7 @@ func NewDAG() *DAG {
 		verticesLocked:   newDMutex(),
 		ancestorsCache:   make(map[interface{}]map[interface{}]struct{}),
 		descendantsCache: make(map[interface{}]map[interface{}]struct{}),
+		options:          defaultOptions(),
 	}
 }
 

--- a/marshal.go
+++ b/marshal.go
@@ -42,12 +42,13 @@ func (d *DAG) UnmarshalJSON(_ []byte) error {
 // }
 //
 // For more specific information please read the test code.
-func UnmarshalJSON(data []byte, wd StorableDAG) (*DAG, error) {
+func UnmarshalJSON(data []byte, wd StorableDAG, options Options) (*DAG, error) {
 	err := json.Unmarshal(data, &wd)
 	if err != nil {
 		return nil, err
 	}
 	dag := NewDAG()
+	dag.Options(options)
 	for _, v := range wd.Vertices() {
 		errVertex := dag.AddVertexByID(v.Vertex())
 		if errVertex != nil {

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -53,7 +53,7 @@ func testMarshalUnmarshalJSON(t *testing.T, d *DAG, expected string) {
 	}
 
 	var wd testStorableDAG
-	dag, err := UnmarshalJSON(data, &wd)
+	dag, err := UnmarshalJSON(data, &wd, defaultOptions())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/options.go
+++ b/options.go
@@ -1,0 +1,27 @@
+package dag
+
+// Options is the configuration for the DAG.
+type Options struct {
+	// VertexHashFunc is the function that calculates the hash value of a vertex.
+	// This can be useful when the vertex contains not comparable types such as maps.
+	// If VertexHashFunc is nil, the defaultVertexHashFunc is used.
+	VertexHashFunc func(v interface{}) interface{}
+}
+
+// Options sets the options for the DAG.
+// Options must be called before any other method of the DAG is called.
+func (d *DAG) Options(options Options) {
+	d.muDAG.Lock()
+	defer d.muDAG.Unlock()
+	d.options = options
+}
+
+func defaultOptions() Options {
+	return Options{
+		VertexHashFunc: defaultVertexHashFunc,
+	}
+}
+
+func defaultVertexHashFunc(v interface{}) interface{} {
+	return v
+}

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,207 @@
+package dag
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+type testNonComparableVertexType struct {
+	ID                 string            `json:"i"`
+	NotComparableField map[string]string `json:"v"`
+}
+
+func TestOverrideVertexHashFunOption(t *testing.T) {
+	dag := NewDAG()
+	/*     1    4
+	 *     |\  /
+	 *     | 2
+	 *     |/
+	 *     3
+	 */
+
+	dag.Options(Options{
+		VertexHashFunc: func(v interface{}) interface{} {
+			return v.(testNonComparableVertexType).ID
+		}})
+
+	testVertex1 := testNonComparableVertexType{
+		ID:                 "1",
+		NotComparableField: map[string]string{"not": "comparable"},
+	}
+	vertexId1, err := dag.addVertex(testVertex1)
+	if err != nil {
+		t.Errorf("Should create a vertex with a not comparable field when a correct VertexHashFunc option is set")
+	}
+
+	testVertex2 := testNonComparableVertexType{
+		ID:                 "2",
+		NotComparableField: map[string]string{"stillNot": "comparable"},
+	}
+	vertexId2, err := dag.addVertex(testVertex2)
+	if err != nil {
+		t.Errorf("Should create a vertex with a not comparable field when a correct VertexHashFunc option is set")
+	}
+	err = dag.AddEdge(vertexId1, vertexId2)
+	if err != nil {
+		t.Errorf("Should create an edge between vertices with not comparable fields when a correct VertexHashFunc option is set")
+	}
+
+	testVertex3 := testNonComparableVertexType{
+		ID:                 "3",
+		NotComparableField: map[string]string{"stillNot": "comparable"},
+	}
+	vertexId3, err := dag.addVertex(testVertex3)
+	if err != nil {
+		t.Errorf("Should create a vertex with a not comparable field when a correct VertexHashFunc option is set")
+	}
+
+	err = dag.AddEdge(vertexId1, vertexId3)
+	if err != nil {
+		t.Errorf("Should create an edge between vertices with not comparable fields when a correct VertexHashFunc option is set")
+	}
+	err = dag.AddEdge(vertexId2, vertexId3)
+	if err != nil {
+		t.Errorf("Should create an edge between vertices with not comparable fields when a correct VertexHashFunc option is set")
+	}
+
+	testVertex4 := testNonComparableVertexType{
+		ID:                 "4",
+		NotComparableField: map[string]string{"stillNot": "comparable"},
+	}
+	vertexId4, err := dag.addVertex(testVertex4)
+	if err != nil {
+		t.Errorf("Should create a vertex with a not comparable field when a correct VertexHashFunc option is set")
+	}
+
+	err = dag.AddEdge(vertexId4, vertexId2)
+	if err != nil {
+		t.Errorf("Should create an edge between vertices with not comparable fields when a correct VertexHashFunc option is set")
+	}
+
+	isEdge, err := dag.IsEdge(vertexId1, vertexId2)
+	if !isEdge || err != nil {
+		t.Errorf("Should return true for edge between vertices with not comparable fields when a correct VertexHashFunc option is set")
+	}
+
+	err = dag.DeleteEdge(vertexId1, vertexId3)
+	if err != nil {
+		t.Errorf("Should delete an edge between vertices with not comparable fields when a correct VertexHashFunc option is set")
+	}
+
+	isEdge, err = dag.IsEdge(vertexId1, vertexId3)
+	if isEdge || err != nil {
+		t.Errorf("Should return false for edge between vertices with not comparable fields when a correct VertexHashFunc option is set")
+	}
+
+	err = dag.DeleteVertex(vertexId2)
+	if err != nil {
+		t.Errorf("Should delete a vertex with not comparable fields when a correct VertexHashFunc option is set")
+	}
+
+	vertexId2, err = dag.addVertex(testVertex2)
+	if err != nil {
+		t.Errorf("Should create a vertex with a not comparable field when a correct VertexHashFunc option is set")
+	}
+
+	_ = dag.AddEdge(vertexId1, vertexId2)
+	_ = dag.AddEdge(vertexId2, vertexId3)
+	err = dag.AddEdge(vertexId4, vertexId2)
+	if err != nil {
+		t.Errorf("Should create an edge between vertices with not comparable fields when a correct VertexHashFunc option is set")
+	}
+
+	roots := dag.GetRoots()
+	if len(roots) != 2 {
+		t.Errorf("Should return 2 roots")
+	}
+	for rootId := range roots {
+		if isRoot, err := dag.IsRoot(rootId); !isRoot || err != nil {
+			t.Errorf("Should return true for root")
+		}
+	}
+
+	leaves := dag.GetLeaves()
+	if len(leaves) != 1 {
+		t.Errorf("Should return 1 leaf")
+	}
+	for leafId := range leaves {
+		if isLeaf, err := dag.IsLeaf(leafId); !isLeaf || err != nil {
+			t.Errorf("Should return true for leaf")
+		}
+	}
+
+	vertex2Parents, err := dag.GetParents(vertexId2)
+	if len(vertex2Parents) != 2 || err != nil {
+		t.Errorf("Should return 2 parents for vertex 2")
+	}
+
+	vertex2Children, err := dag.GetChildren(vertexId2)
+	if len(vertex2Children) != 1 || err != nil {
+		t.Errorf("Should return 1 child for vertex 2")
+	}
+
+	vertex3Ancestors, err := dag.GetAncestors(vertexId3)
+	if len(vertex3Ancestors) != 3 || err != nil {
+		t.Errorf("Should return 3 ancestors for vertex 3, received %d", len(vertex3Ancestors))
+	}
+
+	vertex3OrderedAncestors, err := dag.GetOrderedAncestors(vertexId3)
+	if len(vertex3OrderedAncestors) != 3 || err != nil {
+		t.Errorf("Should return 3 ancestors for vertex 3, received %d", len(vertex3OrderedAncestors))
+	}
+
+	vertex4Descendants, err := dag.GetDescendants(vertexId4)
+	if len(vertex4Descendants) != 2 || err != nil {
+		t.Errorf("Should return 2 descendants for vertex 4, received %d", len(vertex4Descendants))
+	}
+
+	vertex4OrderedDescendants, err := dag.GetOrderedDescendants(vertexId4)
+	if len(vertex4OrderedDescendants) != 2 || err != nil {
+		t.Errorf("Should return 2 descendants for vertex 4, received %d", len(vertex4OrderedDescendants))
+	}
+
+	_, _, err = dag.GetDescendantsGraph(vertexId1)
+	if err != nil {
+		t.Errorf("Should return a string representation of the descendants graph")
+	}
+
+	_, _, err = dag.GetAncestorsGraph(vertexId1)
+	if err != nil {
+		t.Errorf("Should return a string representation of the ancestors graph")
+	}
+
+	_, err = dag.Copy()
+	if err != nil {
+		t.Errorf("Should return a copy of the DAG")
+	}
+
+	dagString := dag.String()
+	if dagString == "" {
+		t.Errorf("Should return a string representation of the DAG")
+	}
+
+	dag.ReduceTransitively()
+	dag.FlushCaches()
+	dag.DescendantsWalker(vertexId1)
+
+	mv := newMarshalVisitor(dag)
+	dag.DFSWalk(mv)
+	dag.BFSWalk(mv)
+	dag.OrderedWalk(mv)
+
+	_, err = dag.MarshalJSON()
+	if err != nil {
+		t.Error(err)
+	}
+
+	data, err := json.Marshal(dag)
+	if err != nil {
+		t.Error(err)
+	}
+
+	var wd testNonComparableStorableDAG
+	_, err = UnmarshalJSON(data, &wd, dag.options)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/storage_test.go
+++ b/storage_test.go
@@ -33,3 +33,33 @@ func (g testStorableDAG) Edges() []Edger {
 	}
 	return l
 }
+
+type testNonComparableStorableVertex struct {
+	Id                  string                      `json:"i"`
+	NotComparableVertex testNonComparableVertexType `json:"v"`
+}
+
+func (tv testNonComparableStorableVertex) Vertex() (id string, value interface{}) {
+	return tv.Id, tv.NotComparableVertex
+}
+
+type testNonComparableStorableDAG struct {
+	StorableVertices []testNonComparableStorableVertex `json:"vs"`
+	StorableEdges    []storableEdge                    `json:"es"`
+}
+
+func (g testNonComparableStorableDAG) Vertices() []Vertexer {
+	l := make([]Vertexer, 0, len(g.StorableVertices))
+	for _, v := range g.StorableVertices {
+		l = append(l, v)
+	}
+	return l
+}
+
+func (g testNonComparableStorableDAG) Edges() []Edger {
+	l := make([]Edger, 0, len(g.StorableEdges))
+	for _, v := range g.StorableEdges {
+		l = append(l, v)
+	}
+	return l
+}

--- a/visitor.go
+++ b/visitor.go
@@ -25,7 +25,7 @@ func (d *DAG) DFSWalk(visitor Visitor) {
 
 	vertices := d.getRoots()
 	for _, id := range reversedVertexIDs(vertices) {
-		v := vertices[id]
+		v := d.vertexIds[id]
 		sv := storableVertex{WrappedID: id, Value: v}
 		stack.Push(sv)
 	}
@@ -43,7 +43,7 @@ func (d *DAG) DFSWalk(visitor Visitor) {
 
 		vertices, _ := d.getChildren(sv.WrappedID)
 		for _, id := range reversedVertexIDs(vertices) {
-			v := vertices[id]
+			v := d.vertexIds[id]
 			sv := storableVertex{WrappedID: id, Value: v}
 			stack.Push(sv)
 		}


### PR DESCRIPTION
Here is my suggestion to resolve issue #33 

I created `option.go` file to centralize all dag options.

I modify the lib such as :

- Exported functions only receive non hashed vertex value
- Package functions only receive hashed vertex value

The `options_test.go` file test all lib features on dag with vertices that contain non comparable type.

Waiting for your review :)